### PR TITLE
refactor: Possible solution for onFetching state reset issue using di…

### DIFF
--- a/src/RTKLoader.tsx
+++ b/src/RTKLoader.tsx
@@ -2,6 +2,14 @@ import { SerializedError } from "@reduxjs/toolkit";
 import * as React from "react";
 import { CustomLoaderProps } from "./types";
 
+const hiddenWrapperStyle = {
+  display: "none",
+};
+
+const shownWrapperStyle = {
+  display: "contents",
+};
+
 export function RTKLoader<T>(
   props: CustomLoaderProps<T>
 ): React.ReactElement {
@@ -9,6 +17,11 @@ export function RTKLoader<T>(
     props.query.isLoading || props.query.isUninitialized;
   const hasError = props.query.isError && props.query.error;
   const isFetching = props.query.isFetching;
+
+  const wrapperStyle =
+    isFetching && props.onFetching
+      ? hiddenWrapperStyle
+      : shownWrapperStyle;
 
   if (shouldLoad) {
     return props.onLoading ?? <React.Fragment />;
@@ -22,10 +35,6 @@ export function RTKLoader<T>(
     );
   }
 
-  if (isFetching && props.onFetching) {
-    return props.onFetching;
-  }
-
   if (props.query.data !== undefined) {
     const prepend = isFetching
       ? props.whileFetching?.prepend ?? null
@@ -33,12 +42,21 @@ export function RTKLoader<T>(
     const append = isFetching
       ? props.whileFetching?.append ?? null
       : null;
+    const onFetchingComponent =
+      isFetching && props.onFetching ? props.onFetching : null;
+
     const componentWithData = props.onSuccess(props.query.data);
 
     return (
       <>
         {prepend}
-        {componentWithData}
+        <div
+          style={wrapperStyle}
+          aria-hidden={isFetching ? true : false}
+        >
+          {componentWithData}
+        </div>
+        {onFetchingComponent}
         {append}
       </>
     );

--- a/src/RTKLoader.tsx
+++ b/src/RTKLoader.tsx
@@ -42,21 +42,27 @@ export function RTKLoader<T>(
     const append = isFetching
       ? props.whileFetching?.append ?? null
       : null;
-    const onFetchingComponent =
-      isFetching && props.onFetching ? props.onFetching : null;
 
     const componentWithData = props.onSuccess(props.query.data);
+
+    if (props.onFetching) {
+      return (
+        <>
+          <div
+            style={wrapperStyle}
+            aria-hidden={isFetching ? true : false}
+          >
+            {componentWithData}
+          </div>
+          {isFetching ? props.onFetching : null}
+        </>
+      );
+    }
 
     return (
       <>
         {prepend}
-        <div
-          style={wrapperStyle}
-          aria-hidden={isFetching ? true : false}
-        >
-          {componentWithData}
-        </div>
-        {onFetchingComponent}
+        {componentWithData}
         {append}
       </>
     );

--- a/testing-app/src/tests.test.tsx
+++ b/testing-app/src/tests.test.tsx
@@ -75,6 +75,12 @@ describe("withLoader", () => {
     await waitFor(() =>
       expect(screen.getByText("Fetching")).toBeVisible()
     );
+    expect(
+      screen.getByRole("textbox", { hidden: true })
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole("textbox", { hidden: false })
+    ).toBeFalsy();
     await waitForElementToBeRemoved(() =>
       screen.queryByText("Fetching")
     );
@@ -105,8 +111,7 @@ describe("withLoader", () => {
     expect(screen.getByRole("textbox")).toHaveValue("Abc");
   });
 
-  // Not wanted behavior, but expected behavior:
-  test("Internal state will reset when using onFetching", async () => {
+  test("Internal state will not reset when using onFetching", async () => {
     render(<FetchTestRenderer />);
     await waitForElementToBeRemoved(() =>
       screen.queryByText("Loading")
@@ -125,7 +130,7 @@ describe("withLoader", () => {
     await waitFor(() =>
       expect(screen.getByText("#3")).toBeVisible()
     );
-    expect(screen.getByRole("textbox")).toHaveValue("");
+    expect(screen.getByRole("textbox")).toHaveValue("Abc");
   });
 
   test("Can use custom loader component", async () => {


### PR DESCRIPTION
A possible solution to the issue regarding internal state being reset while fetching when using the `onFetching` method.

I'm not a big fan of inserting a wrapper div around loaded components, even if it uses `display: contents;`. I will do some research about possible issues with this implementation, and leave this PR open for now. Thoughts, anyone?