### PR TITLE
feat: Working prototype of deferred queries, but with an annoying caveat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,5 @@ dist
 .tern-port
 
 .DS_Store
+
+deploy.mjs

--- a/src/createLoader.ts
+++ b/src/createLoader.ts
@@ -37,8 +37,13 @@ export const createUseLoader = <
           joinedCreatedQueries[index] = query;
         }
       });
+      console.log(joinedCreatedQueries.map((q) => q?.isLoading));
       const aggregatedDeferredQuery = aggregateToQuery(
         joinedCreatedQueries
+      );
+      console.log(
+        "Aggregated state",
+        aggregatedDeferredQuery.isLoading
       );
 
       if (aggregatedDeferredQuery.isSuccess) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,6 +72,11 @@ export type CreateUseLoaderArgs<
   queries: (...args: OptionalGenericArg<A>) => QRU;
   /** Transforms the output of the queries */
   transform?: LoaderTransformFunction<QRU, R>;
+  deferred?: (
+    createResponse: <CR>(val: CR) => UseQueryResult<CR>
+  ) => readonly (UseQueryResult<unknown> | undefined)[];
+  defer?: number[];
+  fallback?: unknown[];
 };
 
 export type UseLoader<A, R> = (

--- a/testing-app/src/mocks.ts
+++ b/testing-app/src/mocks.ts
@@ -21,7 +21,7 @@ export const handlers = [
   }),
   rest.get("/pokemon/:name", (req, res, c) => {
     if (req.params.name === "error") {
-      return res(c.delay(RESPONSE_DELAY), c.status(500));
+      return res(c.delay(RESPONSE_DELAY + 200), c.status(500));
     }
     return res(
       c.delay(RESPONSE_DELAY),

--- a/testing-app/src/mocks.ts
+++ b/testing-app/src/mocks.ts
@@ -21,7 +21,7 @@ export const handlers = [
   }),
   rest.get("/pokemon/:name", (req, res, c) => {
     if (req.params.name === "error") {
-      return res(c.delay(RESPONSE_DELAY + 200), c.status(500));
+      return res(c.delay(RESPONSE_DELAY + 500), c.status(500));
     }
     return res(
       c.delay(RESPONSE_DELAY),

--- a/testing-app/src/tests.test.tsx
+++ b/testing-app/src/tests.test.tsx
@@ -161,22 +161,23 @@ describe("withLoader", () => {
         // Queries that are deferred should be called last
         const deferred = useGetPokemonByNameQuery("charizard");
         return [
-          deferred, // 100ms slower than useGetPokemonsQuery
           notDeferred2,
           notDeferred,
+          deferred, // 100ms slower than useGetPokemonsQuery
         ] as const;
       },
       deferred: (cr) => [
+        undefined,
+        undefined,
         cr({ name: "temp-charizard" }),
-        undefined,
-        undefined,
       ],
       onLoading: () => <div>Loading</div>,
     });
+
     const Component = withLoader(
       (_, loaderData) => (
         <>
-          <div>{loaderData[0].data.name}</div>
+          <div>{loaderData[2].data.name}</div>
         </>
       ),
       loader


### PR DESCRIPTION
You need to call the deferred queries _after_ the queries you don't need to defer in the queries argument for it to work as expected.

Example:

```typescript
const loader = createLoader({
  queries: () => {
    // Queries that are not deferred should be called first
    const notDeferred = useGetPokemonsQuery(undefined);
    // Queries that are deferred should be called last
    const deferred = useGetPokemonByNameQuery("charizard");  // 100ms slower than useGetPokemonsQuery
    
    // The order returned does not matter 
    return [
      deferred,
      notDeferred,
    ] as const;
  },
  deferred: (assignFallback) => [
    assignFallback({ name: "temp-charizard" }), // queries[0]
    undefined, // queries[1]
  ],
  onLoading: () => <div>Loading</div>,
});
```

This would work like this:

1. Loading is visible while loader is loading essential queries (that are not deferred). This this case, the loader is waiting for `useGetPokemonsQuery`.
2. Since `useGetPokemonByNameQuery` is slower, we are giving it a fallback value in the `deferred` argument. This value will be passed to the component while the loader is waiting for the query to resolve in the background.
3. Once `useGetPokemonByNameQuery` resolves, the component will again rerender with the updated loader data.

> In the example above, we don't technically _need_ the second entry in the `deferred` array, since `deferred[1]` would be `undefined` either way, but this of course depends on the order of the queries returned and isn't always applicable.

I'm thinking of merging this as is, so it'll be included in the next release. It's not perfect, but it's atleast something. You could always "defer" queries by not including them in the loader at all, and just calling them in the component body instead. This atleast opens up the option.