### PR TITLE
feat: deferred queries in loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,35 @@ const Component = () => {
 };
 ```
 
+## Deferring queries
+
+You can defer queries by using the `deferredQueries` argument in `createLoader` (or `createUseLoader`). These queries are passed as the second argument to `transform` which has to be used to access the deferred queries in your loaded component.
+
+Example usage:
+
+```tsx
+const loader = createLoader({
+  queries: () => [useImportantQuery()] as const,
+  deferredQueries: () => [useSlowButNotImportantQuery()] as const,
+  transform: (queries, deferredQueries) => ({
+    important: queries[0].data,
+    not_important: deferredQueries[0].data,
+  }),
+});
+
+const Component = withLoader((props, loaderData) => {
+  const { important, not_important } = loaderData;
+  // not_important could be undefined
+
+  return (
+    <div>
+      {important.person.name}
+      {not_important ? "it has resolved : "some fallback"}
+    </div>
+  )
+}, loader);
+```
+
 ## InferLoaderData
 
 Infers the type of the data the loader returns. Use:

--- a/deploy.mjs
+++ b/deploy.mjs
@@ -1,0 +1,23 @@
+#!/usr/bin/env zx
+try {
+  await Promise.all([
+    $`yarn build`,
+    $`npm version patch --force`,
+  ]);
+  const version = require("./package.json").version;
+  await Promise.all([
+    $`git commit --allow-empty -m "version: ${version}"`,
+    $`git push`,
+    $`npm publish --access public`,
+    $`echo "======================"`,
+    $`echo "Deployed! 🚀 (${version})"`,
+    $`echo "======================"`,
+  ]);
+} catch (err) {
+  await Promise.all([
+    $`echo "======================"`,
+    $`echo "Deploy failed! 😭"`,
+    $`echo "======================"`,
+    $`echo "${err}"`,
+  ]);
+}

--- a/testing-app/src/mocks.ts
+++ b/testing-app/src/mocks.ts
@@ -23,8 +23,12 @@ export const handlers = [
     if (req.params.name === "error") {
       return res(c.delay(RESPONSE_DELAY), c.status(500));
     }
+    const delay =
+      req.params.name === "delay"
+        ? RESPONSE_DELAY + 100
+        : RESPONSE_DELAY;
     return res(
-      c.delay(RESPONSE_DELAY),
+      c.delay(delay),
       c.status(200),
       c.json({
         name: req.params.name,


### PR DESCRIPTION
## Deferring queries

You can defer queries by using the `deferredQueries` argument in `createLoader` (or `createUseLoader`). These queries are passed as the second argument to `transform` which has to be used to access the deferred queries in your loaded component.

Example usage:

```tsx
const loader = createLoader({
  queries: () => [useImportantQuery()] as const,
  deferredQueries: () => [useSlowButNotImportantQuery()] as const,
  transform: (queries, deferredQueries) => ({
    important: queries[0].data,
    not_important: deferredQueries[0].data,
  }),
});
const Component = withLoader((props, loaderData) => {
  const { important, not_important } = loaderData;
  // not_important could be undefined
  return (
    <div>
      {important.person.name}
      {not_important ? "it has resolved : "some fallback"}
    </div>
  )
}, loader);
```